### PR TITLE
Reduce cron spamminess

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,28 +1,25 @@
 all: pull allocate commit push
 
 pull:
-	git fetch origin
-	git reset --hard origin/master
-	git clean -f -d v1/
+	@git fetch -q origin
+	@git reset -q --hard origin/master
+	@git clean -q -f -d v1/
 
 allocate: v1/allocated/all
 
 commit: allocate
 	@if [ -s allocate.log ]; then \
-	    echo commiting; \
 	    git add -A v1 config.json; \
 	    git commit --author="allocator <no-reply@mozilla.com>" -q -F allocate.log; \
 	fi
 
 push: commit
-	git push origin
+	@git push -q origin
 
 v1/allocated/all: config.json
-	@echo writing allocations
 	@python manage_jacuzzis.py
 
 config.json:
-	@echo calculating allocations
-	@python allocate.py --db ${DB_URL} 2>&1 | tee allocate.log
+	@python allocate.py --db ${DB_URL} > allocate.log
 
 .PHONY: config.json pull allocate commit push

--- a/allocate.py
+++ b/allocate.py
@@ -17,6 +17,7 @@ Basic flow:
     - Otherwise, if we're less than p_decrease % full for more than
     t_decrease minutes, decrease the jacuzzi
 """
+from __future__ import print_function
 import time
 import json
 import logging
@@ -221,8 +222,10 @@ def main():
         if delta == 0:
             log.debug("%s OK", builder)
         else:
-            log.info("%s currently %is full and %is idle", builder, t_full0, t_idle0)
-            log.info("%s %i (%+i was %i) would result in %is full and %is idle", builder, n, delta, n0, t_full, t_idle)
+            print("%s currently %is full and %is idle" % (builder, t_full0,
+                                                          t_idle0))
+            print("%s %i (%+i was %i) would result in %is full and %is idle" %
+                  (builder, n, delta, n0, t_full, t_idle))
             for spec in 'bld-linux64-spot-', 'b-2008-ix-':
                 if spec in machine_types:
                     machine_types[spec] = max(machine_types[spec] + delta, 0)


### PR DESCRIPTION
(summoning @bhearsum)
- Add @ to make commands to suppress extra output
- Add -q to commands where it's possible. In case of failure they
  produce output for cronjobs anyways.
- Delete some echo commands
- allocate.py should explicitly write to stdout messages used by git
  commit. All other messages should be treated as errors and will be
  consumed by cron. This also makes the script generate the same commit
  message with debug enabled.
