### PR TITLE
Bug 1118510: Use the build submission time as the job start time

### DIFF
--- a/allocate.py
+++ b/allocate.py
@@ -50,7 +50,7 @@ def get_builder_activity(builder, starttime, endtime):
     # should. Or we should let builds break out of jacuzzis if they wait too
     # long
     q = sa.text("""
-                SELECT start_time, finish_time FROM buildrequests, builds WHERE
+                SELECT submitted_at, start_time, finish_time FROM buildrequests, builds WHERE
                 builds.brid = buildrequests.id AND
                 builds.start_time >= :starttime AND
                 builds.start_time < :endtime AND
@@ -62,8 +62,8 @@ def get_builder_activity(builder, starttime, endtime):
     # We've got a list of start/end times now. We need to process them both in
     # sorted time order. For each start time, increase our count; and for each
     # end time, decrease our count
-    times = [(start, 1) for (start, finish) in results]
-    times.extend((finish, -1) for (start, finish) in results if finish)
+    times = [(submitted, 1) for (submitted, start, finish) in results]
+    times.extend((finish, -1) for (submitted, start, finish) in results if finish)
     times.sort()
 
     count = 0


### PR DESCRIPTION
The previous behaviour was to use the actual build start/end time for
figuring out how many machines were needed at any one moment. In the
case where there are many pending jobs, the start time is delayed
relative to the job submission time, and the algorithm doesn't take that
into account. In addition, we calculate the optimal number of machines
here assuming that we can serve every request with a machine, but in
manage_jacuzzis.py we can assign multiple builders to a single machine.

If we use the submit time as the start time, we then are trying to
optimize the amount of time the pool is full/idle beginning from when
the jobs are submitted until they've actually finished. This should
adapt better to cases where too many jobs end up waiting a long time.

The net result of this is that we'll need more slaves allocated to most
builders.