### PR TITLE
Remove old B2G Aurora jacuzzis.

### DIFF
--- a/config.json
+++ b/config.json
@@ -209,36 +209,6 @@
     "b2g_fx-team_linux64_gecko-debug build": {
       "bld-linux64-spot-": 3
     }, 
-    "b2g_mozilla-aurora_emulator-debug_dep": {
-      "bld-linux64-spot-": 1
-    }, 
-    "b2g_mozilla-aurora_emulator-jb-debug_dep": {
-      "bld-linux64-spot-": 1
-    }, 
-    "b2g_mozilla-aurora_emulator-jb_dep": {
-      "bld-linux64-spot-": 1
-    }, 
-    "b2g_mozilla-aurora_emulator_dep": {
-      "bld-linux64-spot-": 1
-    }, 
-    "b2g_mozilla-aurora_flame_eng_dep": {
-      "bld-linux64-spot-": 1
-    }, 
-    "b2g_mozilla-aurora_hamachi_eng_dep": {
-      "bld-linux64-spot-": 1
-    }, 
-    "b2g_mozilla-aurora_linux32_gecko build": {
-      "bld-linux64-spot-": 1
-    }, 
-    "b2g_mozilla-aurora_linux32_gecko-debug build": {
-      "bld-linux64-spot-": 1
-    }, 
-    "b2g_mozilla-aurora_linux64_gecko build": {
-      "bld-linux64-spot-": 1
-    }, 
-    "b2g_mozilla-aurora_linux64_gecko-debug build": {
-      "bld-linux64-spot-": 1
-    }, 
     "b2g_mozilla-central_emulator-debug_dep": {
       "bld-linux64-spot-": 5
     }, 


### PR DESCRIPTION
We aren't going to be running B2G builds on Aurora for awhile. Let's remove them for simplicity's sake.