### PR TITLE
Emulator l

### DIFF
--- a/config.json
+++ b/config.json
@@ -148,7 +148,7 @@
       "bld-linux64-ec2-": 0, 
       "bld-linux64-spot-": 6
     }, 
-    "b2g_b2g-inbound_emulator-jb-debug_dep": {
+    "b2g_b2g-inbound_emulator-l_dep": {
       "bld-linux64-spot-": 6
     }, 
     "b2g_b2g-inbound_emulator-jb_dep": {
@@ -161,28 +161,18 @@
     "b2g_b2g-inbound_flame-kk_eng_dep": {
       "bld-linux64-spot-": 7
     }, 
-    "b2g_b2g-inbound_hamachi_eng_dep": {
-      "bld-linux64-ec2-": 0, 
-      "bld-linux64-spot-": 1
-    }, 
     "b2g_b2g-inbound_linux32_gecko build": {
       "bld-linux64-ec2-": 0, 
       "bld-linux64-spot-": 5
-    }, 
-    "b2g_b2g-inbound_linux32_gecko-debug build": {
-      "bld-linux64-spot-": 3
     }, 
     "b2g_b2g-inbound_linux64_gecko build": {
       "bld-linux64-ec2-": 0, 
       "bld-linux64-spot-": 6
     }, 
-    "b2g_b2g-inbound_linux64_gecko-debug build": {
-      "bld-linux64-spot-": 3
-    }, 
     "b2g_fx-team_emulator-debug_dep": {
       "bld-linux64-spot-": 5
     }, 
-    "b2g_fx-team_emulator-jb-debug_dep": {
+    "b2g_fx-team_emulator-l_dep": {
       "bld-linux64-spot-": 5
     }, 
     "b2g_fx-team_emulator-jb_dep": {
@@ -194,25 +184,16 @@
     "b2g_fx-team_flame-kk_eng_dep": {
       "bld-linux64-spot-": 5
     }, 
-    "b2g_fx-team_hamachi_eng_dep": {
-      "bld-linux64-spot-": 1
-    }, 
     "b2g_fx-team_linux32_gecko build": {
       "bld-linux64-spot-": 4
-    }, 
-    "b2g_fx-team_linux32_gecko-debug build": {
-      "bld-linux64-spot-": 3
     }, 
     "b2g_fx-team_linux64_gecko build": {
       "bld-linux64-spot-": 5
     }, 
-    "b2g_fx-team_linux64_gecko-debug build": {
-      "bld-linux64-spot-": 3
-    }, 
     "b2g_mozilla-central_emulator-debug_dep": {
       "bld-linux64-spot-": 5
     }, 
-    "b2g_mozilla-central_emulator-jb-debug_dep": {
+    "b2g_mozilla-central_emulator-l_dep": {
       "bld-linux64-spot-": 5
     }, 
     "b2g_mozilla-central_emulator-jb_dep": {
@@ -224,26 +205,17 @@
     "b2g_mozilla-central_flame-kk_eng_dep": {
       "bld-linux64-spot-": 5
     }, 
-    "b2g_mozilla-central_hamachi_eng_dep": {
-      "bld-linux64-spot-": 1
-    }, 
     "b2g_mozilla-central_linux32_gecko build": {
       "bld-linux64-spot-": 5
     }, 
-    "b2g_mozilla-central_linux32_gecko-debug build": {
-      "bld-linux64-spot-": 3
-    }, 
     "b2g_mozilla-central_linux64_gecko build": {
       "bld-linux64-spot-": 5
-    }, 
-    "b2g_mozilla-central_linux64_gecko-debug build": {
-      "bld-linux64-spot-": 3
     }, 
     "b2g_mozilla-inbound_emulator-debug_dep": {
       "bld-linux64-ec2-": 0, 
       "bld-linux64-spot-": 12
     }, 
-    "b2g_mozilla-inbound_emulator-jb-debug_dep": {
+    "b2g_mozilla-inbound_emulator-l_dep": {
       "bld-linux64-spot-": 12
     }, 
     "b2g_mozilla-inbound_emulator-jb_dep": {
@@ -255,21 +227,12 @@
     "b2g_mozilla-inbound_flame-kk_eng_dep": {
       "bld-linux64-spot-": 12
     }, 
-    "b2g_mozilla-inbound_hamachi_eng_dep": {
-      "bld-linux64-spot-": 1
-    }, 
     "b2g_mozilla-inbound_linux32_gecko build": {
       "bld-linux64-spot-": 10
-    }, 
-    "b2g_mozilla-inbound_linux32_gecko-debug build": {
-      "bld-linux64-spot-": 4
     }, 
     "b2g_mozilla-inbound_linux64_gecko build": {
       "bld-linux64-ec2-": 0, 
       "bld-linux64-spot-": 9
-    }, 
-    "b2g_mozilla-inbound_linux64_gecko-debug build": {
-      "bld-linux64-spot-": 3
     }
   }
 }

--- a/config.json
+++ b/config.json
@@ -209,36 +209,6 @@
     "b2g_fx-team_linux64_gecko-debug build": {
       "bld-linux64-spot-": 3
     }, 
-    "b2g_mozilla-aurora_emulator-debug_dep": {
-      "bld-linux64-spot-": 1
-    }, 
-    "b2g_mozilla-aurora_emulator-jb-debug_dep": {
-      "bld-linux64-spot-": 1
-    }, 
-    "b2g_mozilla-aurora_emulator-jb_dep": {
-      "bld-linux64-spot-": 1
-    }, 
-    "b2g_mozilla-aurora_emulator_dep": {
-      "bld-linux64-spot-": 1
-    }, 
-    "b2g_mozilla-aurora_flame_eng_dep": {
-      "bld-linux64-spot-": 1
-    }, 
-    "b2g_mozilla-aurora_hamachi_eng_dep": {
-      "bld-linux64-spot-": 1
-    }, 
-    "b2g_mozilla-aurora_linux32_gecko build": {
-      "bld-linux64-spot-": 1
-    }, 
-    "b2g_mozilla-aurora_linux32_gecko-debug build": {
-      "bld-linux64-spot-": 1
-    }, 
-    "b2g_mozilla-aurora_linux64_gecko build": {
-      "bld-linux64-spot-": 1
-    }, 
-    "b2g_mozilla-aurora_linux64_gecko-debug build": {
-      "bld-linux64-spot-": 1
-    }, 
     "b2g_mozilla-central_emulator-debug_dep": {
       "bld-linux64-spot-": 5
     }, 


### PR DESCRIPTION
* Emulator-JB debug & Linux32/64 Gecko debug were made periodic, so remove them from jacuzzis.
* Remove Hamachi builds because they're no longer built in automation.
* Add Emulator-L opt builds.